### PR TITLE
Store, accept string room and user IDs

### DIFF
--- a/client/squawkers.js
+++ b/client/squawkers.js
@@ -95,7 +95,7 @@ class SquawkerItem extends React.Component {
     const videoStream = this.getVideoStream();
     if (videoStream) {
       videoStream.getTracks().forEach(track => conn.addTrack(track, videoStream));
-    } 
+    }
     if (audioStream) {
       audioStream.getTracks().forEach(track => conn.addTrack(track, audioStream));
     }
@@ -207,14 +207,14 @@ class SquawkerItem extends React.Component {
           controls: true,
           muted: true,
           src: squawker.audioUrl,
-          ref: (audio) => this.audioEl = audio 
+          ref: (audio) => this.audioEl = audio
         }),
         e("video", {
           crossOrigin: 'anonymous',
           controls: true,
           muted: true,
           src: squawker.videoUrl,
-          ref: (video) => this.videoEl = video 
+          ref: (video) => this.videoEl = video
         })
       )
     );
@@ -332,8 +332,8 @@ class SquawkerApp extends React.Component {
 }
 
 const serverUrl = params.get("janus") || `wss://${location.hostname}:8989`;
-const roomId = params.get("room") || 0;
+const roomId = params.get("room") || "0";
 const ws = new WebSocket(serverUrl, "janus-protocol");
 const session = new Minijanus.JanusSession(ws.send.bind(ws), { verbose: true });
 const root = document.getElementById("root");
-ReactDOM.render(e(SquawkerApp, { ws: ws, session: session, roomId: parseInt(roomId) }), root);
+ReactDOM.render(e(SquawkerApp, { ws: ws, session: session, roomId: roomId }), root);

--- a/client/tiny.js
+++ b/client/tiny.js
@@ -1,6 +1,6 @@
 const params = new URLSearchParams(location.search.slice(1));
 var USER_ID = Math.floor(Math.random() * (1000000001));
-const roomId = params.get("room") != null ? parseInt(params.get("room")) : 42;
+const roomId = params.get("room") != null ? params.get("room") : "42";
 
 const PEER_CONNECTION_CONFIG = {
   iceServers: [
@@ -163,7 +163,7 @@ async function attachPublisher(session) {
 
   await waitForEvent("webrtcup", handle);
   showStatus(`Joining room ${roomId}...`);
-  const reply = await handle.sendMessage({ 
+  const reply = await handle.sendMessage({
     kind: "join",
     room_id: roomId,
     user_id: USER_ID,

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,8 +53,8 @@ join a room. You can only join one room with any connection.
 ```
 {
     "kind": "join",
-    "room_id": unsigned integer ID
-    "user_id": unsigned integer ID,
+    "room_id": room ID
+    "user_id": user ID,
     "subscribe": [none|subscription object]
 }
 ```
@@ -68,7 +68,7 @@ The response will return the current directory of users on the server by room, a
 ```
 {
     "success": true,
-    "user_ids": {1: [123, 789], 2: [456]}
+    "user_ids": {room_alpha: ["123", "789"], room_beta: ["456"]}
 }
 ```
 
@@ -85,7 +85,7 @@ Lists the current directory of users on the server by room, including you, if yo
 ```
 {
     "success": true,
-    "user_ids": {1: [123, 789], 2: [456]}
+    "user_ids": {room_alpha: ["123", "789"], room_beta: ["456"]}
 }
 ```
 
@@ -97,7 +97,7 @@ Subscribes to some kind of traffic coming from the server.
 {
     "notifications": [none|boolean],
     "data": [none|boolean],
-    "media": [none|unsigned integer user ID]
+    "media": [none|user ID]
 }
 ```
 
@@ -112,7 +112,7 @@ The response will return the current directory of users on the server by room, a
 ```
 {
     "success": true,
-    "user_ids": {1: [123, 789], 2: [456]}
+    "user_ids": {room_alpha: ["123", "789"], room_beta: ["456"]}
 }
 ```
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,15 +1,56 @@
 /// Types and code related to handling signalling messages.
+use std::fmt;
 use super::Sdp;
 use super::auth::UserToken;
+use serde::de::{self, Deserialize, Deserializer, Visitor};
 
 /// A room ID representing a Janus multicast room.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct RoomId(pub u64);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct RoomId(pub String);
 
 /// A user ID representing a single Janus client. Used to correlate multiple Janus connections back to the same
 /// conceptual user for managing subscriptions.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct UserId(pub u64);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct UserId(pub String);
+
+struct IdVisitor;
+
+impl<'de> Visitor<'de> for IdVisitor {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("string or numeric identifier")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<String, E>
+    {
+        Ok(value.into())
+    }
+
+    fn visit_string<E: de::Error>(self, value: String) -> Result<String, E>
+    {
+        Ok(value)
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<String, E>
+    {
+        Ok(value.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<RoomId, D::Error>
+    {
+        deserializer.deserialize_any(IdVisitor).map(|x| RoomId(x))
+    }
+}
+
+impl<'de> Deserialize<'de> for UserId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<UserId, D::Error>
+    {
+        deserializer.deserialize_any(IdVisitor).map(|x| UserId(x))
+    }
+}
 
 /// Useful to represent a JSON message field which may or may not be present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,7 +96,7 @@ pub enum MessageKind {
 }
 
 /// Information about which traffic a client will get pushed to them.
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct Subscription {
     /// Whether to subscribe to server-wide notifications (e.g. user joins and leaves, room creates and destroys).
@@ -108,11 +149,11 @@ mod tests {
 
         #[test]
         fn parse_join_user_id() {
-            let json = r#"{"kind": "join", "user_id": 10, "room_id": 5}"#;
+            let json = r#"{"kind": "join", "user_id": 10, "room_id": "alpha"}"#;
             let result: MessageKind = serde_json::from_str(json).unwrap();
             assert_eq!(result, MessageKind::Join {
-                user_id: UserId(10),
-                room_id: RoomId(5),
+                user_id: UserId("10".into()),
+                room_id: RoomId("alpha".into()),
                 subscribe: None,
                 token: None,
             });
@@ -123,8 +164,8 @@ mod tests {
             let json = r#"{"kind": "join", "user_id": 10, "room_id": 5, "subscribe": {"notifications": true, "data": false}}"#;
             let result: MessageKind = serde_json::from_str(json).unwrap();
             assert_eq!(result, MessageKind::Join {
-                user_id: UserId(10),
-                room_id: RoomId(5),
+                user_id: UserId("10".into()),
+                room_id: RoomId("5".into()),
                 subscribe: Some(Subscription {
                     notifications: true,
                     data: false,
@@ -136,13 +177,13 @@ mod tests {
 
         #[test]
         fn parse_subscribe() {
-            let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": 4}}"#;
+            let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": "steve"}}"#;
             let result: MessageKind = serde_json::from_str(json).unwrap();
             assert_eq!(result, MessageKind::Subscribe {
                 what: Subscription {
                     notifications: false,
                     data: true,
-                    media: Some(UserId(4)),
+                    media: Some(UserId("steve".into()))
                 }
             });
         }


### PR DESCRIPTION
Now room IDs and user IDs are arbitrary strings. Would be nice to fix unnecessary copying but this implementation should be OK for now.

For the moment, we continue to accept numeric JSON IDs in signalling messages; later, once client code is updated, we'll break backwards compatibility. This change does make the user IDs returned in signalling responses into strings, which could break client code, but ours is resilient to that (and since IDs are opaque and only good for comparing equality probably other code is also resilient to that.)