### PR TITLE
Implement configurable maximum server-wide CCU

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,12 +6,16 @@ use std::path::Path;
 /// All of the runtime configuration for the plugin.
 #[derive(Debug, Clone)]
 pub struct Config {
-    pub max_room_size: usize
+    pub max_room_size: usize,
+    pub max_ccu: usize
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self { max_room_size: usize::max_value() }
+        Self {
+            max_room_size: usize::max_value(),
+            max_ccu: usize::max_value()
+        }
     }
 }
 
@@ -29,6 +33,10 @@ impl Config {
                 .get("max_room_size")
                 .and_then(|x| x.parse().ok())
                 .unwrap_or(defaults.max_room_size),
+            max_ccu: section
+                .get("max_ccu")
+                .and_then(|x| x.parse().ok())
+                .unwrap_or(defaults.max_ccu),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,11 +365,15 @@ fn process_join(from: &Arc<Session>, room_id: RoomId, user_id: UserId, subscribe
 
     let mut is_master_handle = false;
     if let Some(subscription) = subscribe.as_ref() {
-        let max_room_size = STATE.config.get().unwrap().max_room_size;
-        let room_is_full = switchboard.occupants_of(&room_id).len() >= max_room_size;
+        let config = STATE.config.get().unwrap();
+        let room_is_full = switchboard.occupants_of(&room_id).len() > config.max_room_size;
+        let server_is_full = switchboard.sessions().len() > config.max_ccu;
         is_master_handle = subscription.data; // hack -- assume there is only one "master" data connection per user
         if is_master_handle && room_is_full {
             return Err(From::from("Room is full."))
+        }
+        if is_master_handle && server_is_full {
+            return Err(From::from("Server is full."))
         }
     }
 

--- a/src/switchboard.rs
+++ b/src/switchboard.rs
@@ -168,6 +168,10 @@ impl Switchboard {
         self.publisher_to_subscribers.get_keys(subscriber)
     }
 
+    pub fn sessions(&self) -> &Vec<Box<Arc<Session>>> {
+        &self.sessions
+    }
+
     pub fn occupants_of(&self, room: &RoomId) -> &[Arc<Session>] {
         self.occupants.get(room).map(Vec::as_slice).unwrap_or(&[])
     }


### PR DESCRIPTION
This is a nice failsafe to have around in case we have some kind of load-related problem after launch.

Also, `max_room_size` is now an inclusive instead of exclusive upper bound, which seems to make more sense.