### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,5 +1,30 @@
 /// Types and code related to handling signalling messages.
-use super::Sdp;
+use super::{Sdp, JanssonEncodingFlags, JanssonValue};
+use super::serde_json;
+use std::error::Error;
+use std::ffi::CStr;
+use std::fmt;
+use std::os::raw::c_char;
+use serde::de::DeserializeOwned;
+
+/// A Janus transaction ID. Used to correlate signalling requests and responses.
+#[derive(Debug)]
+pub struct TransactionId(pub *mut c_char);
+
+unsafe impl Send for TransactionId {}
+
+impl fmt::Display for TransactionId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unsafe {
+            if self.0.is_null() {
+                f.write_str("<null>")
+            } else {
+                let contents = CStr::from_ptr(self.0);
+                f.write_str(&contents.to_string_lossy())
+            }
+        }
+    }
+}
 
 /// A room ID representing a Janus multicast room.
 pub type RoomId = String;
@@ -15,6 +40,30 @@ pub type UserId = String;
 pub enum OptionalField<T> {
     Some(T),
     None {}
+}
+
+impl<T> Into<Option<T>> for OptionalField<T> {
+    fn into(self) -> Option<T> {
+        match self {
+            OptionalField::None {} => None,
+            OptionalField::Some(x) => Some(x)
+        }
+    }
+}
+
+impl<T> OptionalField<T> where T: DeserializeOwned {
+    pub fn try_parse(val: &Option<JanssonValue>) -> Option<Result<T, Box<Error>>> {
+        val.as_ref().and_then(|x| match parse_json::<OptionalField<T>>(x).map(|x| x.into()) {
+            Ok(None) => None,
+            Ok(Some(y)) => Some(Ok(y)),
+            Err(e) => Some(Err(e))
+        })
+    }
+}
+
+fn parse_json<T>(json: &JanssonValue) -> Result<T, Box<Error>> where T: DeserializeOwned {
+    let json_str = json.to_libcstring(JanssonEncodingFlags::empty());
+    Ok(serde_json::from_str::<T>(json_str.to_str()?)?)
 }
 
 /// A signalling message carrying a JSEP SDP offer or answer.

--- a/src/txid.rs
+++ b/src/txid.rs
@@ -1,0 +1,22 @@
+use std::ffi::CStr;
+use std::fmt;
+use std::os::raw::c_char;
+
+/// A Janus transaction ID. Used to correlate signalling requests and responses.
+#[derive(Debug)]
+pub struct TransactionId(pub *mut c_char);
+
+unsafe impl Send for TransactionId {}
+
+impl fmt::Display for TransactionId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unsafe {
+            if self.0.is_null() {
+                f.write_str("<null>")
+            } else {
+                let contents = CStr::from_ptr(self.0);
+                f.write_str(&contents.to_string_lossy())
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is mostly aimed at making logging output much more useful and readable, by waiting until things are dereferenced/parsed to log them. To accomplish that sanely a reasonable amount of refactoring in the signalling message parsing was necessary.

Also snuck in the use of new `impl Trait` stuff to make switchboard interface not allocate per-packet.