### PR TITLE
Authorize and kick

### DIFF
--- a/scripts/setup-and-run-janus.sh
+++ b/scripts/setup-and-run-janus.sh
@@ -42,10 +42,12 @@ docopts -h - : "$@" <<EOF
 Usage: ./setup-and-run-social-mr-janus-server.sh [--force-rebuild] [--working-directory <dir>]
 
     -f --force-rebuild               Forcefully rebuild dependencies
+    -l --build-local                 Build local code instead of master
     -d --working-directory <dir>     Directory to work under [default: ./build]
 EOF
 )"
 
+build_local=$([[ $build_local == "true" ]] && echo "true") || true
 force_rebuild=$([[ $force_rebuild == "true" ]] && echo "true") || true
 
 script_directory=$(dirname "$0")
@@ -118,7 +120,7 @@ if [[ $force_rebuild || ! -e /opt/janus/bin/janus ]]; then
     popd
 fi
 
-if [[ $force_rebuild || ! -e /opt/janus/lib/janus/plugins/libjanus_plugin_sfu.so ]]; then
+if [[ ! -e /opt/janus/lib/janus/plugins/libjanus_plugin_sfu.so ]]; then
     banner 'installing latest rust'
     curl https://sh.rustup.rs -sSf > rustup.sh
     sh rustup.sh -y
@@ -126,21 +128,22 @@ if [[ $force_rebuild || ! -e /opt/janus/lib/janus/plugins/libjanus_plugin_sfu.so
     rm rustup.sh
     rustup update
 
-    banner 'getting, building and installing janus-plugin-sfu'
-    # git-get mquander/janus-plugin-sfu master
-    # pushd mquander/janus-plugin-sfu
-    # cargo build --release
-    # sudo mkdir -p /opt/janus/lib/janus/plugins
-    # sudo cp target/release/libjanus_plugin_sfu.so /opt/janus/lib/janus/plugins/
-    # popd
+    if [[ $build_local ]]; then
+        pushd "$script_directory/.."
+        cargo build --release
+        sudo mkdir -p /opt/janus/lib/janus/plugins
+        sudo cp target/release/libjanus_plugin_sfu.so /opt/janus/lib/janus/plugins/
+        popd
+    else
+        banner 'getting, building and installing janus-plugin-sfu'
+        git-get mquander/janus-plugin-sfu master
+        pushd mquander/janus-plugin-sfu
+        cargo build --release
+        sudo mkdir -p /opt/janus/lib/janus/plugins
+        sudo cp target/release/libjanus_plugin_sfu.so /opt/janus/lib/janus/plugins/
+        popd
+    fi
 fi
-
-pushd ../../
-echo $PWD
-cargo build --release
-sudo mkdir -p /opt/janus/lib/janus/plugins
-sudo cp target/release/libjanus_plugin_sfu.so /opt/janus/lib/janus/plugins/
-popd
 
 if [ "$(awk '/\[nat\]/,/^stun/' /opt/janus/etc/janus/janus.cfg | wc -l)" -gt "2" ]; then
     sudo sed 's/\[nat\]/\0\nstun_server = stun2.l.google.com\nstun_port = 19302/' -i /opt/janus/etc/janus/janus.cfg
@@ -159,16 +162,16 @@ banner 'starting janus and web servers'
 
 /opt/janus/bin/janus &
 
-# pushd "$script_directory/../client"
-# if [[ ! -e server.pem ]]; then
-#     banner 'generating ssl cert'
-#     openssl req -nodes -x509 -newkey rsa:2048 -keyout server.key -out server.pem -days 365 \
-#         -subj "/C=US/ST=CA/L=MTV/O=foo/OU=foo/CN=foo"
-# fi
-# twistd -no web --path . -c server.pem -k server.key --https=443 &
-# popd
+pushd "$script_directory/../client"
+if [[ ! -e server.pem ]]; then
+    banner 'generating ssl cert'
+    openssl req -nodes -x509 -newkey rsa:2048 -keyout server.key -out server.pem -days 365 \
+        -subj "/C=US/ST=CA/L=MTV/O=foo/OU=foo/CN=foo"
+fi
+twistd -no web --path . -c server.pem -k server.key --https=443 &
+popd
 
-trap "kill %1; wait" SIGINT
+trap "kill %1; kill %2; wait" SIGINT
 sleep 1
 banner 'press Ctrl+C to kill'
 wait

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,51 +1,26 @@
 use super::jwt;
 use super::jwt::{Algorithm, Validation};
-use messages::UserId;
-use std::fmt;
 use std::error::Error;
-
-#[derive(Debug)]
-struct SubjectParseError;
-
-impl Error for SubjectParseError {
-    fn description(&self) -> &str {
-        "Failed to parse JWT subject; expected User:UID."
-    }
-}
-
-impl fmt::Display for SubjectParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
-    }
-}
-
-fn parse_user_subject(sub: &str) -> Result<UserId, SubjectParseError> {
-    let separator_idx = sub.find(':').ok_or(SubjectParseError)?;
-    let namespace = &sub[0..separator_idx];
-    let ident = &sub[separator_idx+1..];
-    if namespace == "User" {
-        ident.parse().map_err(|_| SubjectParseError)
-    } else {
-        Err(SubjectParseError)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedToken {
-    pub sub: UserId,
+    pub join_hub: bool,
+    pub kick_users: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct UserClaims {
-   sub: String,
+   join_hub: bool,
+   kick_users: bool,
 }
 
 impl ValidatedToken {
     pub fn from_str(value: &str, key: &[u8]) -> Result<ValidatedToken, Box<Error>> {
-        let mut validation = Validation::new(Algorithm::RS512);
-        validation.validate_exp = false;
+        let validation = Validation::new(Algorithm::RS512);
         let token_data = jwt::decode::<UserClaims>(value, key, &validation)?;
-        let subject = parse_user_subject(&token_data.claims.sub)?;
-        Ok(ValidatedToken { sub: subject })
+        Ok(ValidatedToken {
+           join_hub: token_data.claims.join_hub,
+           kick_users: token_data.claims.kick_users,
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,8 +408,8 @@ fn process_join(from: &Arc<Session>, room_id: RoomId, user_id: UserId, subscribe
     match (&config.auth_key, token) {
         (Some(ref key), Some(ref token)) => {
             match ValidatedToken::from_str(token, key) {
-                Ok(_tok) => {
-                    janus_info!("Processing validated join from {:p} to room ID {} with user ID {}.", from.handle, room_id, user_id);
+                Ok(tok) => {
+                    janus_info!("Processing validated join from {:p} to room ID {} with user ID {}. Join allowed: {}", from.handle, room_id, user_id, tok.join_hub);
                 }
                 Err(e) => {
                     janus_warn!("Processing invalid join from {:p} to room ID {} with user ID {} ({})", from.handle, room_id, user_id, e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,8 +476,14 @@ fn process_kick(from: &Arc<Session>, room_id: RoomId, user_id: UserId, token: St
                 if tok.kick_users {
                     janus_info!("Processing kick from {:p} targeting user ID {} in room ID {}.", from.handle, user_id, room_id);
                     let end_session = gateway_callbacks().end_session;
-                    let mut switchboard = STATE.switchboard.write()?;
-                    end_session(switchboard.get_publisher(&user_id).unwrap().as_ref().as_ptr());
+                    let switchboard = STATE.switchboard.read()?;
+                    let sessions = switchboard.get_sessions(&user_id);
+                    for sess in sessions {
+                        janus_info!("Kicking session {:p}.", from.handle);
+                        end_session(sess.as_ptr());
+                    }
+                } else {
+                    janus_warn!("Ignoring kick from {:p} because they didn't have kick permissions.", from.handle);
                 }
             }
             Err(e) => {

--- a/src/switchboard.rs
+++ b/src/switchboard.rs
@@ -261,4 +261,16 @@ impl Switchboard {
             })
             .map(Box::as_ref)
     }
+
+    pub fn get_sessions(&self, user_id: &UserId) -> Vec<&Box<Arc<Session>>> {
+        self.sessions.iter()
+            .filter(|s| {
+                let join_state = s.join_state.get();
+                match join_state {
+                    Some(state) if &state.user_id == user_id => true,
+                    _ => false
+                }
+            }).collect::<_>()
+    }
+
 }


### PR DESCRIPTION
- Just extract join and kick claims from JWT, instead of trying to parse subject.
- Actually act on kick message by verifying claim and calling `end_session` on given publisher