### PR TITLE
Clean up join authorization logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,31 +405,28 @@ extern "C" fn hangup_media(handle: *mut PluginSession) {
 fn process_join(from: &Arc<Session>, room_id: RoomId, user_id: UserId, subscribe: Option<Subscription>, token: Option<String>) -> MessageResult {
     // todo: holy shit clean this function up somehow
     let config = STATE.config.get().unwrap();
-    match &config.auth_key {
-        Some(ref key) => {
-            match token {
-                Some(ref token) => {
-                    match ValidatedToken::from_str(token, key) {
-                        Ok(tok) => {
-                            janus_warn!("Processing validated join from {:p} to room ID {} with user ID {}. Join allowed: {}", from.handle, room_id, user_id, tok.join_hub);
-                            if !tok.join_hub {
-                                return Err(From::from("Rejecting join with no join_hub permission!"))
-                            }
-                        }
-                        Err(e) => {
-                            janus_warn!("Processing invalid join from {:p} to room ID {} with user ID {}. Error: {}", from.handle, room_id, user_id, e);
-                            return Err(From::from("Rejecting join with invalid token!"))
-                        }
-                    }
-                },
-                _ => {
-                    janus_warn!("Processing anonymous join from {:p} to room ID {} with user ID {}.", from.handle, room_id, user_id);
-                    return Err(From::from("Rejecting anonymous join!"))
+    match (&config.auth_key, token) {
+        (None, _) => {
+            janus_verb!("No auth_key configured. Allowing join from {:p} to room {} as user {}.", from.handle, room_id, user_id);
+        }
+        (Some(_), None) => {
+            janus_warn!("Rejecting anonymous join from {:p} to room {} as user {}.", from.handle, room_id, user_id);
+            return Err(From::from("Rejecting anonymous join!"))
+        }
+        (Some(key), Some(ref token)) => {
+            match ValidatedToken::from_str(token, key) {
+                Ok(ref claims) if claims.join_hub => {
+                    janus_verb!("Allowing validated join from {:p} to room {} as user {}.", from.handle, room_id, user_id);
+                }
+                Ok(_) => {
+                    janus_warn!("Rejecting unauthorized join from {:p} to room {} as user {}.", from.handle, room_id, user_id);
+                    return Err(From::from("Rejecting join with no join_hub permission!"))
+                }
+                Err(e) => {
+                    janus_warn!("Rejecting invalid join from {:p} to room {} as user {}. Error: {}", from.handle, room_id, user_id, e);
+                    return Err(From::from("Rejecting join with invalid token!"))
                 }
             }
-        },
-        _ => {
-            janus_warn!("No auth_key configured. Allowing join from {:p} to room ID {} with user ID {}.", from.handle, room_id, user_id);
         }
     }
 


### PR DESCRIPTION
This version seems more readable to me. Also, fixed log messages to not warn in the common case of allowed joins.