### PR TITLE
Attempt faster lookup of publishers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ fn process_join(from: &Arc<Session>, room_id: RoomId, user_id: UserId, subscribe
         };
         if is_master_handle {
             let notification = json!({ "event": "join", "user_id": user_id, "room_id": room_id });
-            switchboard.join_room(Arc::clone(from), room_id.clone());
+            switchboard.join_room(Arc::clone(from), user_id.clone(), room_id.clone());
             notify_except(&notification, &user_id, switchboard.occupants_of(&room_id));
         }
         if let Some(ref publisher_id) = subscription.media {


### PR DESCRIPTION
Refactors `get_publisher` to use a new hashmap to reduce the need to walk all sessions when fetching publishers. Instead, we now only walk the sessions in the first room the user joined. `get_sessions` could also be refactored but proved challenging for me.

Also it seems that `get_publisher` assumes a user is only publishing in one room (ie, has one subscriber offer across all of their joined rooms), but `get_sessions` assumes a user can be joined in several rooms. So this PR may be a bad idea, since the new hashmap now assumes a user is going to publish from the first room they join. I wasn't sure of the original assumptions being made in switchboard - in practice users only join one room in hubs for both publishing and subscribing. This PR assumes that the first room a user joins is the one they will be publishing in - if that isn't the case (ie they join two rooms, and publish in the second one), the hashmap will register them in the wrong room and their publisher will not be discoverable. However I believe currently the SFU requires publishing in all joined rooms for other reasons, so maybe this is a moot point. If not a better but more complex approach would be to have the hashmap be registered into if/when the user begins publishing.