### PR TITLE
Refactor & fix switchboard join/leave tracking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,8 +701,6 @@ fn handle_message_async(RawMessage { jsep, msg, txn, from }: RawMessage) -> Janu
     if let Some(ref from) = from.upgrade() {
         janus_huge!("Processing txid {} from {:p}: msg={:?}, jsep={:?}", txn, from.handle, msg, jsep);
         if !from.destroyed.load(Ordering::Relaxed) {
-            // process the message first, because processing a JSEP can cause us to want to send an RTCP
-            // FIR to our subscribers, which may have been established in the message
             let parsed_msg = msg.and_then(|x| try_parse_jansson(&x).transpose());
             let parsed_jsep = jsep.and_then(|x| try_parse_jansson(&x).transpose());
             let msg_result = parsed_msg.map(|x| x.and_then(|msg| process_message(from, msg)));

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -6,9 +6,19 @@ use once_cell::sync::OnceCell;
 use std::sync::atomic::{AtomicBool, AtomicIsize};
 use std::sync::{Arc, Mutex};
 
-/// State pertaining to this session's join of a particular room as a particular user ID.
+/// Once they join a room, all sessions are classified as either subscribers or publishers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinKind {
+    Publisher,
+    Subscriber,
+}
+
+/// State pertaining to all sessions that have joined a room.
 #[derive(Debug, Clone)]
 pub struct JoinState {
+    /// Whether this session is a subscriber or a publisher.
+    pub kind: JoinKind,
+
     /// The room ID that this session is in.
     pub room_id: RoomId,
 
@@ -17,10 +27,11 @@ pub struct JoinState {
 }
 
 impl JoinState {
-    pub fn new(room_id: RoomId, user_id: UserId) -> Self {
-        Self { room_id, user_id }
+    pub fn new(kind: JoinKind, room_id: RoomId, user_id: UserId) -> Self {
+        Self { kind, room_id, user_id }
     }
 }
+
 
 /// The state associated with a single session.
 #[derive(Debug)]
@@ -28,17 +39,21 @@ pub struct SessionState {
     /// Whether this session has been destroyed.
     pub destroyed: AtomicBool,
 
+    /// The current FIR sequence number for this session's video.
+    pub fir_seq: AtomicIsize,
+
     /// Information pertaining to this session's user and room, if joined.
     pub join_state: OnceCell<JoinState>,
 
-    /// The subscription this user has established, if any.
+    // todo: these following fields should be unified with the JoinState, but it's
+    // annoying in practice because they are established during JSEP negotiation
+    // rather than during the join flow
+
+    /// If this is a subscriber, the subscription this user has established, if any.
     pub subscription: OnceCell<Subscription>,
 
     /// If this is a publisher, the offer for subscribing to it.
     pub subscriber_offer: Arc<Mutex<Option<Sdp>>>,
-
-    /// The current FIR sequence number for this session's video.
-    pub fir_seq: AtomicIsize,
 }
 
 /// Rust representation of a single Janus session, i.e. a single `RTCPeerConnection`.


### PR DESCRIPTION
**WIP -- haven't tested yet. Just putting it here in case it's useful to you.**

This fixes #52 and changes the switchboard data structures to be more sympathetic to how we're using them. We can now do `get_publisher` in constant time and kicking users also got faster. Hopefully the code also got cleaner and harder to mess up.

To do still:

- [ ] Change "user" terminology to "client" to be less misleading.
- [x] Tag whether a session is a publisher or a subscriber in the session state.