### PR TITLE
Use SWITCHBOARD.read() instead of SWITCHBOARD.write() in process_data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,7 @@ fn process_subscribe(from: &Arc<Session>, what: &Subscription) -> MessageResult 
 fn process_data(from: &Arc<Session>, whom: Option<UserId>, body: &str) -> MessageResult {
     janus_huge!("Processing data message from {:p}: {:?}", from.handle, body);
     let payload = json!({ "event": "data", "body": body });
-    let switchboard = SWITCHBOARD.write()?;
+    let switchboard = SWITCHBOARD.read().expect("Switchboard lock poisoned; can't continue.");
     if let Some(joined) = from.join_state.get() {
         let occupants = switchboard.publishers_occupying(&joined.room_id);
         if let Some(user_id) = whom {


### PR DESCRIPTION
See my comment https://github.com/mozilla/janus-plugin-sfu/issues/62#issuecomment-770406570
We don't seem to change anything in process_data, using `read()` instead of `write()` is better to not block concurrent execution with message_threads > 1.

Or is there something I'm missing?