### PR TITLE
Remove multimap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ version = "0.1.0"
 dependencies = [
  "janus-plugin",
  "jsonwebtoken",
- "multimap",
  "num_cpus",
  "once_cell",
  "rust-ini",
@@ -169,15 +168,6 @@ name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-
-[[package]]
-name = "multimap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ lto = true
 
 [dependencies]
 janus-plugin = { git = "https://github.com/mozilla/janus-plugin-rs" }
-multimap = "0.8"
 once_cell = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This wasn't really pulling its weight, and killing it decreases the surface area for bugs like #62.

Also now we don't leak an empty vec in maps for every user and room that ever exists which is nice.