### PR TITLE
Use level verb instead of info for the 'Queueing signalling message' log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -761,7 +761,7 @@ extern "C" fn handle_message(
                 msg: unsafe { JanssonValue::from_raw(message) },
                 jsep: unsafe { JanssonValue::from_raw(jsep) },
             };
-            janus_info!("Queueing signalling message on {:p}.", sess.handle);
+            janus_verb!("Queueing signalling message on {:p}.", sess.handle);
             let message_count = MESSAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
             let senders = MESSAGE_SENDERS.get().unwrap();
             let sender = &senders[message_count % senders.len()];


### PR DESCRIPTION
Using log level info (level 4) and using websocket for naf components update, you can really have a lot of logs, several times per second for an user. Lower it to verb (level 5)