### PR TITLE
End old publisher session sooner when publisher reconnect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,7 +774,7 @@ extern "C" fn handle_message(
                 msg: unsafe { JanssonValue::from_raw(message) },
                 jsep: unsafe { JanssonValue::from_raw(jsep) },
             };
-            janus_info!("Queueing signalling message on {:p}.", sess.handle);
+            janus_verb!("Queueing signalling message on {:p}.", sess.handle);
             let message_count = MESSAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
             let senders = MESSAGE_SENDERS.get().unwrap();
             let sender = &senders[message_count % senders.len()];


### PR DESCRIPTION
I create this PR in draft so this has some visibility, if anyone is interested by this change. This is what I have currently in production.
See discussion starting at https://github.com/mozilla/janus-plugin-sfu/issues/62#issuecomment-770877418

If a user has a network failure and they reconnects, you could have with naf-janus-adapter the message
"Janus still has previous session for this client. Reconnecting in 10s." three times.
With this changes ending the old publisher session sooner (not waiting that janus detects the RTCPeerConnection is dead), the message "Janus still has previous session for this client. Reconnecting in 10s." only appears once, so the user really reconnect sooner so that the other participants can hear them again.