### PR TITLE
Add optional room_ids to JWT

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,17 +1,41 @@
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
+use crate::messages::RoomId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedToken {
     pub join_hub: bool,
     pub kick_users: bool,
+    pub room_ids: Option<Vec<RoomId>>
+}
+
+impl ValidatedToken {
+    pub fn may_join(&self, room_id: &RoomId) -> bool {
+        if self.join_hub {
+            if let Some(allowed_rooms) = &self.room_ids {
+                if allowed_rooms.contains(room_id) { // this token explicitly lets you in this room
+                    true
+                } else { // this token lets you in some rooms, but not this one
+                    false
+                }
+            } else { // this token lets you in any room
+                true
+            }
+        } else {
+            false // this token disallows joining entirely
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct UserClaims {
+    #[serde(default)]
     join_hub: bool,
+    #[serde(default)]
     kick_users: bool,
+    #[serde(default)]
+    room_ids: Option<Vec<RoomId>>
 }
 
 impl ValidatedToken {
@@ -22,6 +46,7 @@ impl ValidatedToken {
         Ok(ValidatedToken {
             join_hub: token_data.claims.join_hub,
             kick_users: token_data.claims.kick_users,
+            room_ids: token_data.claims.room_ids,
         })
     }
 }


### PR DESCRIPTION
Implements #78. Now if JWT authorization is enabled, you may join a room only if you send a JWT containing `join_hub = true` and with either no `room_ids` (i.e. like all old tokens; you can join any room) or a `room_ids` array containing the room ID you're trying to join.

Not yet tested, so not merging yet.